### PR TITLE
Update Cypht source code URL

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ maintainers = ["eric_G"]
 license = "LGPL-2.1-only"
 website = "https://cypht.org"
 admindoc = "https://cypht.org/install.html"
-code = "https://github.com/jasonmunro/cypht"
+code = "https://github.com/cypht-org/cypht"
 
 [integration]
 yunohost = ">= 11.2"


### PR DESCRIPTION
Cypht is now a GitHub organization:
https://unencumberedbyfacts.com/2023/06/14/cypht-rebooted/

## Problem

- The URL was outdated

## Solution

- I updated the URL

## PR Status

- [x] Code finished and ready to be reviewed/tested

