### PR TITLE
Update the app version installed shown on the installation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All your E-mail, from all your accounts, in one place. Cypht is not your father'
 Cypht is an application built entirely of plugins, or as we call them, module sets (which is obviously way cooler sounding than plugins), that are executed by the framework. Modules provide a flexible way to add new features or customize the program without hacking the code.
 
 
-**Shipped version:** 1.4.0~ynh1
+**Shipped version:** 1.4.1~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 
 Cypht est un client de messagerie web. Vous pouvez accéder à vos comptes de messagerie qui supportent IMAP, POP3 ou SMTP - comme la plupart.
 
-**Version incluse :** 1.4.0~ynh1
+**Version incluse :** 1.4.1~ynh1
 
 ## Captures d’écran
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Cypht"
 description.en = "Lightweight Open Source webmail"
 description.fr = "Webmail Open Source léger"
 
-version = "1.4.0~ynh1"
+version = "1.4.1~ynh1"
 
 maintainers = ["eric_G"]
 


### PR DESCRIPTION
## Problem

- The app manifest resources.sources.main has been updated to the latest cypht version but "installed version" on the installation page still show the version 1.4.0

## Solution

- Update the version shown in the app description
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
